### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order('created_at DESC')
-   
   end
 
   def new
@@ -11,23 +10,23 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item=Item.find((params[:id]))
+    @item = Item.find((params[:id]))
   end
 
-  #def edit
-    #item = Item.find(params[:id])
-  #end
-   
-  #def update
-    #item = Item.find(params[:id])
-    #item.update(item_params)
-  #end
+  # def edit
+  # item = Item.find(params[:id])
+  # end
 
-  #def destroy
-    #item = Item.find(params[:id])
-    #item.destroy
-  #end
-  
+  # def update
+  # item = Item.find(params[:id])
+  # item.update(item_params)
+  # end
+
+  # def destroy
+  # item = Item.find(params[:id])
+  # item.destroy
+  # end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,15 +3,33 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order('created_at DESC')
+   
   end
 
   def new
     @item = Item.new
   end
 
+  def show
+    @item=Item.find((params[:id]))
+  end
+
+  #def edit
+    #item = Item.find(params[:id])
+  #end
+   
+  #def update
+    #item = Item.find(params[:id])
+    #item.update(item_params)
+  #end
+
+  #def destroy
+    #item = Item.find(params[:id])
+    #item.destroy
+  #end
+  
   def create
     @item = Item.new(item_params)
-
     if @item.save
       redirect_to items_path
     else

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       <% @items.each do |item| %>
       <%# 商品のインスタンス変数の中身のすべてを展開 %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %> 
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
           <% if %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <% if %><%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%end%><%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         <%= @item.scheduled_delivery.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,64 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% if %><%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%end%><%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.scheduled_delivery.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <% if user_signed_in? %><%# ログインユーザーが出品している表示 %>
+   <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+   <%else%><%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <%end%><%# //商品が売れていない場合はこちらを表示しましょう %>
+  <%end%>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.sales_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_free_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
   <% if user_signed_in? %><%# ログインユーザーが出品している表示 %>
-   <% if user_signed_in? && current_user.id == @item.user_id %>
+   <% if current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
@@ -100,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items
   
 end


### PR DESCRIPTION
『商品詳細に関する実装』
・ログイン状態の出品者のみ、「編集・削除ボタン」が表示される
現在では、一度投稿した内容の変更ができないため。
https://gyazo.com/35da983eab5e03e97bb9f3c14efe4639

・ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示される
現在では、出品者が購入できてしまうため。
https://gyazo.com/5898a06c2a541da47d70ae94f6d34dc5

・ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できる、「編集・削除・購入画面に進むボタン」が表示されない
ユーザー登録していない人でも、商品の詳細をみて欲しいが、個人情報がない状態で「編集・削除・購入」されては困るため。
https://gyazo.com/b9c90f03743997d300be195b0f8f91a6



・ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
商品の売却に関する表示なので、商品購入機能の実装後でいいのでしょうか？


確認お願いします。

